### PR TITLE
[config] Adjust connenction

### DIFF
--- a/teamplan/Sources/Network/NetworkService.swift
+++ b/teamplan/Sources/Network/NetworkService.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 class NetworkService {
-    private let baseURL = "http://todopang.uk"
+    private let baseURL = "https://todopang.uk"
     private let session: Session
     private var token: String?
     
@@ -44,7 +44,7 @@ class NetworkService {
         ]
         
         if let token = token {
-            headers["Token"] = token
+            headers["Authorization"] = "Bearer \(token)"
         }
         
         // Request 로깅

--- a/teamplan/Sources/ViewModels/AuthenticationViewModel.swift
+++ b/teamplan/Sources/ViewModels/AuthenticationViewModel.swift
@@ -134,11 +134,15 @@ final class AuthenticationViewModel: ObservableObject {
                                                 
                       Task {
                           do {
-                              let authResult = try await Auth.auth().signIn(with: credential)
-                              let user = authResult.user
- 
+                              let user = try await Auth.auth().signIn(with: credential).user
                               
-                              let test = try await self.authRepository.tryLogin(token: idToken, userId: user.uid)
+                              // FirebaseAuth IdToken 추출
+                              guard let firebaseIdToken = try await Auth.auth().currentUser?.getIDTokenResult() else {
+                                  continuation.resume(throwing: NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to get FirebaseID token"]))
+                                  return
+                              }
+                              
+                              let test = try await self.authRepository.tryLogin(token: firebaseIdToken.token, userId: user.uid)
                               continuation.resume(returning: ())
                           } catch {
                               continuation.resume(throwing: error)


### PR DESCRIPTION
## Key Changes
* 서버도메인 수정
  * 기존 'http' 접근 시, 서버에서 https 리다이렉트 요청을 반환하여 오류 발생
  * 도메인 호출 방식을 'https' 로 변경
* Firebase IdToken 추출과정 추가
  * 현재 Header 에 업로드된 Token 값은 GoogleSocialLogin 에서 받은 Token 값
  * FirebaseAuth 에서 발급하는 IdToken 값과 다르기에 서버에서 오류를 발생시키고 있음을 확인
  * Google 소셜로그인 이후, 로그인된 Firebase User 객체에서 TokenId를 추출하는 로직 추가
  
  
## To Reviewers
Apple Login 구현 시에도, FirebaseAuth 에서 추출된 IdToken 값을 Header에 넣어주시면 정상적으로 동작될 것으로 보입니다!
